### PR TITLE
Add helper usage and version-based build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # bcl_convert
 Illumina BCL Convert software containerized for cross platform use
+
+## Building
+
+This repository contains a helper script, `get_latest_rpm_url.py`, which
+scrapes Illumina's download page and prints the URL of the latest CentOS7 RPM.
+
+```bash
+python3 get_latest_rpm_url.py
+```
+
+Download that RPM into the repository and build the image by passing the
+corresponding version number to the Docker build:
+
+```bash
+# Download the RPM
+curl -LO "$(python3 get_latest_rpm_url.py)"
+
+# Extract the version from the file name
+VERSION=$(ls bcl-convert-*-2.el7.x86_64.rpm | sed -n 's/.*bcl-convert-\(.*\)-2.el7.x86_64.rpm/\1/p')
+
+docker build --build-arg BCLCONVERT_VERSION="$VERSION" -t bcl_convert .
+```
+
+The Dockerfile expects the RPM to be present in the build context.

--- a/get_latest_rpm_url.py
+++ b/get_latest_rpm_url.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Fetch the latest CentOS7 bcl-convert RPM URL from Illumina."""
+import re
+import sys
+import urllib.request
+
+DOWNLOADS_URL = "https://support.illumina.com/sequencing/sequencing_software/bcl-convert/downloads.html"
+
+pattern = re.compile(r'(https?://[^"\s]*bcl-convert-(\d+(?:\.\d+)*)-2\.el7\.x86_64\.rpm)')
+
+with urllib.request.urlopen(DOWNLOADS_URL) as resp:
+    html = resp.read().decode()
+
+best_version = None
+best_url = None
+
+for match in pattern.finditer(html):
+    url, version = match.groups()
+    ver_tuple = tuple(int(x) for x in version.split('.'))
+    if best_version is None or ver_tuple > best_version:
+        best_version = ver_tuple
+        best_url = url
+
+if not best_url:
+    sys.exit("No RPM URL found on page")
+
+print(best_url)


### PR DESCRIPTION
## Summary
- revert Dockerfile to use a `BCLCONVERT_VERSION` ARG instead of downloading automatically
- document how to use `get_latest_rpm_url.py` to fetch the RPM and build an image

## Testing
- `python3 get_latest_rpm_url.py | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_686593ec1f048323848c5a968d65c8d7